### PR TITLE
Center Calender Widget modal in screen

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -19,14 +19,16 @@
     data-expapp-gallery-shop-url="experiences-v2-dev-minh.myshopify.com"
     data-expapp-gallery-base-url="https://expapp-minh.ngrok.io/api"></div> -->
 
-    <!-- <div
-      data-expapp-calendar-booking-form
-      data-expapp-calendar-booking-form-storefront-access-token="8de4c41e34f5d912a51c8c7748101908"
-      data-expapp-calendar-booking-form-buy-sdk="true"
-      data-expapp-calendar-booking-form-product-id="4637285777454"
-      data-expapp-calendar-booking-form-shop-url="new-production-qa-4.myshopify.com"
-      data-expapp-calendar-booking-form-base-url="https://prod-v2-api.experiencesapp.services"
-    ></div> -->
+    <div style="width: 100vw; text-align: center; transform: translate3d(0, 0, 0)">
+      <div style="height: 100vh">Shop Content Here</div>
+      <div
+        data-expapp-calendar-booking-form
+        data-expapp-calendar-booking-form-storefront-access-token="8de4c41e34f5d912a51c8c7748101908"
+        data-expapp-calendar-booking-form-product-id="4637285777454"
+        data-expapp-calendar-booking-form-shop-url="new-production-qa-4.myshopify.com"
+        data-expapp-calendar-booking-form-base-url="https://prod-v2-api.experiencesapp.services"
+      ></div>
+    </div>
     <script src="/dist/widgets.js"></script>
   </body>
   <!-- data-expapp-calendar-booking-form-buy-sdk="true" -->

--- a/src/SharedComponents/Modal/Modal.tsx
+++ b/src/SharedComponents/Modal/Modal.tsx
@@ -1,64 +1,87 @@
+import './_modal.scss';
 
-import { h, Component, createRef } from "preact";
-import "./_modal.scss";
-import { Portal } from "../../calendarBookingForm/Components/Portal";
+import { Component, createRef, h } from 'preact';
+
+import { Portal } from '../../calendarBookingForm/Components/Portal';
 
 type ModalProps = {
-    /** sets the prop if the mobal should be visiable or not */
-    showModal: boolean;
-    /** sets the prop if the mobal is at the order details portion */
-    orderDetails: string;
-    /** method to will trigger when to close the modal view */
-    closeModal(): void;
+  /** sets the prop if the mobal should be visiable or not */
+  showModal: boolean;
+  /** sets the prop if the mobal is at the order details portion */
+  orderDetails: string;
+  /** method to will trigger when to close the modal view */
+  closeModal(): void;
 };
 
-type ModalState = {
-};
+type ModalState = {};
 /** this componet renders the modal view  */
 export class Modal extends Component<ModalProps, ModalState> {
-    constructor(props: ModalProps) {
-        super(props);
+  constructor(props: ModalProps) {
+    super(props);
+  }
+
+  /** Ref to the modal element */
+  modal = createRef();
+
+  /** Add event listener for page scroll to fix modal to center of screen */
+  componentDidMount() {
+    window.addEventListener("scroll", this.handleCenterModal);
+  }
+
+  /** Add event listener to the document for clicks */
+  componentWillMount() {
+    document.addEventListener("mousedown", this.handleClickOutsideModal, false);
+  }
+
+  /** Remove event listener for page scroll */
+  componentWillUnmount() {
+    window.removeEventListener("scroll", this.handleCenterModal);
+  }
+
+  /** On page scroll, move modal to stay fixed to the center of the screen */
+  handleCenterModal = () => {
+    if (!this.modal.current) {
+      return;
     }
 
-    /** Ref to the modal element */
-    modal = createRef();
+    this.modal.current.css("position", "absolute");
+    this.modal.current.css("top", document.body.scrollHeight + "px");
+  };
 
-    /** Add event listener to the document for clicks */
-    componentWillMount() {
-        document.addEventListener("mousedown", this.handleClickOutsideModal, false);
+  /** On click, check if click was outside modal and close if so */
+  handleClickOutsideModal = (e: Event) => {
+    if (!!this.modal.current) {
+      if (this.modal.current.contains(e.target as Node)) {
+        return;
+      }
     }
+    this.props.closeModal();
+  };
 
-    /** On click, check if click was outside modal and close if so */
-    handleClickOutsideModal = (e: Event) => {
-        if (!!this.modal.current) {
-            if (this.modal.current.contains(e.target as Node)) {
-                return;
-            }
-        }
-        this.props.closeModal();
+  /** rendering the modal container */
+  render() {
+    if (this.props.showModal) {
+      const { children, orderDetails } = this.props;
+      let orderModal = orderDetails === "OrderDetails" ? true : false;
+
+      return (
+        <Portal>
+          <div>
+            <div class="Exp__App_Modal">
+              <div
+                ref={this.modal}
+                class={`Exp__App_Modal__ModalContentBox${
+                  !!orderModal ? "OrderDetails" : ""
+                }`}
+              >
+                <div class="Modal-ModalMainContentBox">{children}</div>
+              </div>
+            </div>
+          </div>
+        </Portal>
+      );
+    } else {
+      return null;
     }
-
-    /** rendering the modal container */
-    render() {
-        if (this.props.showModal) {
-            const { children, orderDetails } = this.props;
-            let orderModal = (orderDetails === "OrderDetails") ? true : false;
-
-            return (
-                <Portal>
-                    <div>
-                        <div class="Exp__App_Modal">
-                            <div ref={this.modal} class={`Exp__App_Modal__ModalContentBox${!!orderModal ? "OrderDetails" : ""}`}>
-                                <div class="Modal-ModalMainContentBox">
-                                    {children}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </Portal>
-            );
-        } else {
-            return null;
-        }
-    }
+  }
 }

--- a/src/SharedComponents/Modal/Modal.tsx
+++ b/src/SharedComponents/Modal/Modal.tsx
@@ -44,8 +44,7 @@ export class Modal extends Component<ModalProps, ModalState> {
       return;
     }
 
-    this.modal.current.css("position", "absolute");
-    this.modal.current.css("top", document.body.scrollHeight + "px");
+    this.modal.current.style.top = window.scrollY + "px";
   };
 
   /** On click, check if click was outside modal and close if so */

--- a/src/SharedComponents/Modal/_modal.scss
+++ b/src/SharedComponents/Modal/_modal.scss
@@ -8,7 +8,7 @@
     height: 90vh;
     opacity: 1;
     z-index: 2000;
-    position: fixed;
+    position: absolute;
     padding: 7% 0%;
     overflow-y: auto;
     &__ModalContentBoxOrderDetails, &__ModalContentBox {

--- a/src/SharedComponents/Modal/_modal.scss
+++ b/src/SharedComponents/Modal/_modal.scss
@@ -1,7 +1,9 @@
 
 .Exp__App_Modal {
-    top: 0;
-    left: 0;
+    top: 50%;
+    left: 50%;
+    margin-left: -50vw;
+    margin-top: -45vh;
     width: 100vw;
     height: 90vh;
     opacity: 1;


### PR DESCRIPTION
Due to the styling of some shops (like https://black-cat-clothing-co.myshopify.com/products/silk-screening-102) which uses `transform: translate3d` in a top-level node which breaks `position: fixed` behavior, using JS to adjust the modal to center of the screen on scroll.

~~TODO:~~
~~- Fix z-index issue with transform/absolute positioning: https://www.freecodecamp.org/news/4-reasons-your-z-index-isnt-working-and-how-to-fix-it-coder-coder-6bc05f103e6c/~~

![image](https://user-images.githubusercontent.com/4753705/91506735-ae41d380-e887-11ea-9e67-6f87ab3d19e3.png)
