### PR TITLE
Aggregate view: preserve mouse X coordinate on event click

### DIFF
--- a/src/SharedComponents/Calendar/CalendarDaySchedule.scss
+++ b/src/SharedComponents/Calendar/CalendarDaySchedule.scss
@@ -6,7 +6,6 @@ dialog[open] {
   padding: 0;
   z-index: 1000;
   position: absolute;
-  top: 40vh;
   margin: 0 auto;
   width: 300px;
   border: 1px solid #DADADA;

--- a/src/SharedComponents/Calendar/CalendarDaySchedule.tsx
+++ b/src/SharedComponents/Calendar/CalendarDaySchedule.tsx
@@ -7,6 +7,10 @@ import { format } from "date-fns";
 interface ICalendarDayScheduleProps {
   open: boolean;
   handleClose(): void;
+  dialogPosition?: {
+    pageX: number;
+    pageY: number;
+  };
   title: string;
   events: CalendarEvent[];
 }
@@ -29,12 +33,15 @@ export class CalendarDaySchedule extends Component<ICalendarDayScheduleProps, an
   }
 
   render() {
-    const { title, open, events } = this.props;
+    const { title, open, events, dialogPosition } = this.props;
+    const style = { 
+      top: dialogPosition && dialogPosition.pageY ? dialogPosition.pageY - 100 : 0,
+    };
 
     if (!open) { return null; }
 
     return (
-      <dialog ref={this.dialogRef} open={open} className="Calendar-DaySchedule">
+      <dialog ref={this.dialogRef} open={open} className="Calendar-DaySchedule" style={style}>
         <div className="Calendar-DaySchedule-Header">
           <div>{title}</div>
           <div>

--- a/src/aggregateView/Components/CalendarMain.tsx
+++ b/src/aggregateView/Components/CalendarMain.tsx
@@ -31,6 +31,10 @@ interface ICalendarContainerProps {
 interface ICalendarContainerState {
   view: string;
   daySelected?: Date;
+  dialogPosition: {
+    pageX: number;
+    pageY: number;
+  };
   events: CalendarEvent[];
   fullCalendarEvents: FullCalendarEvent[];
   daySelectedEvents: CalendarEvent[];
@@ -46,6 +50,10 @@ export class CalendarContainer extends Component<ICalendarContainerProps, ICalen
   state: ICalendarContainerState = {
     view: calendarViewType.dayGrid,
     events: [],
+    dialogPosition: {
+      pageX: 0,
+      pageY: 0
+    },
     fullCalendarEvents: [],
     daySelected: null,
     daySelectedEvents: [],
@@ -77,9 +85,10 @@ export class CalendarContainer extends Component<ICalendarContainerProps, ICalen
     return <CalendarNoEventsMessage  onNextAvailableClick={this.navigateToNextAvailableTS} />;
   };
 
-  handleEventClick = ({ event: { _def, _instance }}: CalendarEventClick) => {
+  handleEventClick = ({ event: { _def, _instance }, jsEvent: { pageX, pageY }}: CalendarEventClick) => {
+    const dialogPosition = { pageX, pageY };
     const eventSelected = this.state.events.find(e => _def.publicId.includes(e.id));
-    this.setState({ daySelected: _instance.range.start, daySelectedEvents: [eventSelected] });
+    this.setState({ daySelected: _instance.range.start, daySelectedEvents: [eventSelected], dialogPosition });
   };
 
   selectView = (view: string) => {
@@ -88,17 +97,18 @@ export class CalendarContainer extends Component<ICalendarContainerProps, ICalen
     this.setState({ view });
   };
 
-  handleMoreClick = ({ date }: DateClickEvent) => {
+  handleMoreClick = ({ date, jsEvent: { pageX, pageY } }: DateClickEvent) => {
+    const dialogPosition = { pageX, pageY };
     const earliest = new Date(date).getTime();
     const latest = new Date(date).setHours(23, 59, 59);
     const daySelectedEvents = this.state.events.filter(e => e.start.getTime() >= earliest && e.end.getTime() < latest);
-    this.setState({ daySelected: date, daySelectedEvents });
+    this.setState({ daySelected: date, daySelectedEvents, dialogPosition });
   };
 
   handleClose = () => this.setState({ daySelected: null });
 
   render() {
-    const { fullCalendarEvents, view, daySelected, daySelectedEvents } = this.state;
+    const { fullCalendarEvents, view, daySelected, daySelectedEvents, dialogPosition } = this.state;
     const titleFormat = window && window.innerWidth >= 1024 ? null : { month: "short", year: "numeric" };
 
     return (
@@ -107,6 +117,7 @@ export class CalendarContainer extends Component<ICalendarContainerProps, ICalen
         <div className="AggregateCalendar-Main">
           <CalendarViewSelector view={view} selectView={this.selectView} />
           <CalendarDaySchedule
+            dialogPosition={dialogPosition}
             open={!!daySelected && !!daySelectedEvents.length}
             handleClose={this.handleClose}
             title={daySelected ? format(daySelected, "MMMM d, y") : ""}

--- a/src/typings/Calendar.ts
+++ b/src/typings/Calendar.ts
@@ -27,6 +27,7 @@ export type DateClickEvent = {
 };
 
 export type CalendarEventClick = {
+  jsEvent: MouseEvent;
   event: {
     _def: {
       publicId: string;


### PR DESCRIPTION
When a user clicks on event or "+x more" the dialog used to open in at a static position. Now it follows the mouse (vertically). Horizontally it's sitting in the middle (for consistency around screen edges)