### PR TITLE
4873 Fetch new events on paddle click

### DIFF
--- a/src/SharedComponents/Calendar/CalendarWrapper.tsx
+++ b/src/SharedComponents/Calendar/CalendarWrapper.tsx
@@ -31,6 +31,8 @@ export interface ICalendarProps {
     weekday?: string; // "long" | "short"
   };
   noEventsContent: JSX.Element;
+  customButtons?: any;
+  headerToolbar?: any;
 };
 
 export type CalendarEvent = {
@@ -65,7 +67,9 @@ export class Calendar extends Component<ICalendarProps, any> {
       noEventsContent, 
       dayMaxEventRows, 
       eventClick,
-      moreLinkClick
+      moreLinkClick,
+      customButtons,
+      headerToolbar
     } = this.props;
 
     const FullCalendarCast = FullCalendar as unknown;
@@ -76,6 +80,8 @@ export class Calendar extends Component<ICalendarProps, any> {
         plugins={[dayGridPlugin, listPlugin, interactionPlugin]}
         initialView={view}
         events={events}
+        customButtons={customButtons}
+        headerToolbar={headerToolbar}
         eventContent={eventContent}
         dateClick={dateClick}
         eventClick={eventClick}

--- a/src/calendarBookingForm/Views/MainIndex/index.tsx
+++ b/src/calendarBookingForm/Views/MainIndex/index.tsx
@@ -165,7 +165,14 @@ export class CalendarWidgetMain extends Component<
 
       // select day and timeslot when coming from aggregate view (or elsewhere)
       const date = getQueryVariable("select");
-      const selectedDate = date && !isNaN(+date) ? new Date(+date * 1000) : new Date();
+      const ms = +date * 1000;
+      if (Date.now() + ms > Date.now() + TIMESPAN_IN_SECONDS) {
+        await this.fetchRangeOfAvailability(
+          this.state.now,
+          ms,
+        );
+      }
+      const selectedDate = date && !isNaN(+date) ? new Date(ms) : new Date();
       const selectedDateTimeslots = date ? getTimeslotsByDate(availability, selectedDate) : [];
       const selectedTimeslot = selectedDateTimeslots.find(ts => (new Date(ts.startsAt)).getTime() === +date * 1000) || null;
 


### PR DESCRIPTION
- Listen to click events natively and fetch new data
- Track already fetched data to avoid excess requests
- Make sure to fetch wider range of events when forwarded to Booking Modal widget with the new date