### PR TITLE
78 Retain customer data

### DIFF
--- a/src/calendarBookingForm/Views/MainIndex/index.tsx
+++ b/src/calendarBookingForm/Views/MainIndex/index.tsx
@@ -461,6 +461,10 @@ export class CalendarWidgetMain extends Component<
     index?: number,
   ) => {
     const { event, selectedTimeslot } = this.state;
+    const firstName: { value?: string, label?: string } = customFormFieldValues ? customFormFieldValues.find(({ label }) => label === "First Name") : {};
+    const lastName: { value?: string, label?: string } = customFormFieldValues ? customFormFieldValues.find(({ label }) => label === "Last Name") : {};
+    const name = (firstName.value || lastName.value) ? `${firstName ? firstName.value : ""} ${lastName ? lastName.value : ""}` : "N/A";
+    const email: { value?: string, label?: string } = customFormFieldValues ? customFormFieldValues.find(({ label }) => label === "Email") : {};
 
     const eventId = event._id.toString();
 
@@ -475,6 +479,14 @@ export class CalendarWidgetMain extends Component<
       timezone: selectedTimeslot.timezone,
       quantity: 1,
       customOrderDetailsValues: customFormFieldValues,
+      attendee: {
+        // @ts-ignore
+        checkedInAt: null,
+        info: {
+          name,
+          email: email ? email.value : "N/A",
+        },
+      },
     };
 
     let newLineItems = this.state.lineItems;

--- a/src/calendarBookingForm/Views/MainIndex/index.tsx
+++ b/src/calendarBookingForm/Views/MainIndex/index.tsx
@@ -32,8 +32,13 @@ import { AvailabilityPage } from "../Availability/AvailabilityPage";
 import { ConfirmPage } from "../Confirmation/ConfirmPage";
 import { OrderDetailsPage } from "../OrderDetails/OrderDetailsPage";
 import "./CalendarWidgetMain.scss";
+import { FormField } from "../../../typings/CustomForm";
 
-
+enum CUSTOM_FIELDS_TO_SKIP {
+  firstName = "First Name",
+  lastName = "Last Name",
+  email = "Email",
+}
 
 /** 32 days expressed in seconds, used to fetch new availability */
 const TIMESPAN_IN_SECONDS = 32 * 24 * 60 * 60;
@@ -461,10 +466,18 @@ export class CalendarWidgetMain extends Component<
     index?: number,
   ) => {
     const { event, selectedTimeslot } = this.state;
-    const firstName: { value?: string, label?: string } = customFormFieldValues ? customFormFieldValues.find(({ label }) => label === "First Name") : {};
-    const lastName: { value?: string, label?: string } = customFormFieldValues ? customFormFieldValues.find(({ label }) => label === "Last Name") : {};
-    const name = (firstName.value || lastName.value) ? `${firstName ? firstName.value : ""} ${lastName ? lastName.value : ""}` : "N/A";
-    const email: { value?: string, label?: string } = customFormFieldValues ? customFormFieldValues.find(({ label }) => label === "Email") : {};
+    const firstName: Partial<FormField> = customFormFieldValues ?
+      customFormFieldValues.find(({ label }) => label === CUSTOM_FIELDS_TO_SKIP.firstName) : {};
+    const lastName: Partial<FormField> = customFormFieldValues ?
+      customFormFieldValues.find(({ label }) => label === CUSTOM_FIELDS_TO_SKIP.lastName) : {};
+    const name = ((firstName && firstName.value) || (lastName && lastName.value)) ?
+      `${firstName ? firstName.value : ""} ${lastName ? lastName.value : ""}` : "N/A";
+    const email: Partial<FormField> = customFormFieldValues ?
+      customFormFieldValues.find(({ label }) => label === CUSTOM_FIELDS_TO_SKIP.email) : {};
+
+    // remove attendee info from custom form fields
+    const filteredCustomFormFieldValues = customFormFieldValues ? customFormFieldValues.filter(({ label }) =>
+      !Object.values(CUSTOM_FIELDS_TO_SKIP).includes(label)) : undefined;
 
     const eventId = event._id.toString();
 
@@ -478,7 +491,7 @@ export class CalendarWidgetMain extends Component<
       endsAt: selectedTimeslot.endsAt,
       timezone: selectedTimeslot.timezone,
       quantity: 1,
-      customOrderDetailsValues: customFormFieldValues,
+      customOrderDetailsValues: filteredCustomFormFieldValues,
       attendee: {
         // @ts-ignore
         checkedInAt: null,

--- a/src/calendarBookingForm/Views/OrderDetails/OrderDetailsPage.tsx
+++ b/src/calendarBookingForm/Views/OrderDetails/OrderDetailsPage.tsx
@@ -180,21 +180,26 @@ export class OrderDetailsPage extends Component<
 
   /** Passed down to the custom form and triggered on changes to store the values in state */
   handleCustomFormChange = (fieldLabelIndex: string, fieldValue: string) => {
-    const defaultForm: FormFieldValueInput[] = this.props.event.customOrderDetails.fields.map(field => ({ label: field.label, value: field.defaultValue }));
+    const newCurrentCustomFormValues: FormFieldValueInput[] = this.props.event.customOrderDetails.fields.map(field => ({ ...field, value: field.defaultValue }));
 
     //Copy the current values to a new array
-    let currentCustomFormValues = defaultForm.concat(this.state.currentCustomFormValues);
+    this.state.currentCustomFormValues.forEach((v, i) => {
+      newCurrentCustomFormValues[i] = v;
+    });
+
     //fieldLabelIndex is the field label/name and its index position joined by a hyphen
     //Split the values apart here
     const [label, index] = fieldLabelIndex.split("-");
+
     //Create a new custom form value of type FormFieldValueInput
-    const newCustomFormValue = { label, value: fieldValue };
+    const oldVal = newCurrentCustomFormValues[parseInt(index)] || {};
+
     //Index into the form values array using the index from the field ID
-    currentCustomFormValues[parseInt(index)] = newCustomFormValue;
+    newCurrentCustomFormValues[parseInt(index)] = { ...oldVal, label, value: fieldValue };
 
     //Set state with the updated value
     this.setState({
-      currentCustomFormValues,
+      currentCustomFormValues: newCurrentCustomFormValues,
     });
   }
 


### PR DESCRIPTION
- Make sure custom form fields get passed to the `createOrder` endpoint
- Omit "Email", "First Name", "Last Name" fields from `customOrderDetails` list
- Make sure "Email", "First Name", "Last Name" get passed as attendee info