### PR TITLE
Adds formatted Currency to Experiences Full page widget

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -224,7 +224,7 @@ export default [
             "cloneElement",
             "options",
           ],
-          "node_modules/ramda/dist/ramda.js": ["clone"],
+          "node_modules/ramda/dist/ramda.js": ["clone", "equals"],
         },
       }),
     ],

--- a/src/fullPageBookingForm/Components/App.tsx
+++ b/src/fullPageBookingForm/Components/App.tsx
@@ -10,7 +10,7 @@ import { Confirmation } from "./Views/Confirmation";
 import { WidgetDataProvider } from "./WidgetDataProvider";
 import { useEventStore } from "../Hooks/useEventStore";
 import { useTimeslotStore } from "../Hooks/useTimeslotStore";
-import { getEventCustomLabels } from "../../Utils/api";
+import { getEventCustomLabels, getShopDetails } from "../../Utils/api";
 import { useEffect, useState } from "preact/hooks";
 import {
   AppDictionary,
@@ -42,6 +42,7 @@ export const App: FunctionComponent<AppProps> = ({
   shopifyProductId,
   languageCode,
 }) => {
+  const [moneyFormat, setMoneyFormat] = useState("${{amount}}");
   const [initialCustomerFormStore] = useState<CustomerFormStore>(
     useCustomerFormStore.getState(),
   );
@@ -61,6 +62,22 @@ export const App: FunctionComponent<AppProps> = ({
     useOrderDetailsStore.setState(initialOrderDetailsStore, true);
     useQtySelectionStore.setState(initialQtySelectionStore, true);
   };
+
+  //Updates money format on mount.
+  useEffect(() => {
+    try {
+      const updateMoneyFormat = async () => {
+        const shop = await getShopDetails({ baseUrl, shopId: shopUrl });
+
+        setMoneyFormat(shop.moneyFormat);
+      };
+
+      updateMoneyFormat();
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
+
   //Reset store data on unmount
   useEffect(() => {
     return resetOrderDetailsStores;
@@ -125,7 +142,7 @@ export const App: FunctionComponent<AppProps> = ({
         onClose={handleClose}
       >
         <WizardModal.Page page={BookingFormPage.TIMESLOT_SELECTION}>
-          <TimeslotSelection />
+          <TimeslotSelection moneyFormat={moneyFormat} />
         </WizardModal.Page>
         <WizardModal.Page page={BookingFormPage.ORDER_DETAILS}>
           <OrderDetails
@@ -134,6 +151,7 @@ export const App: FunctionComponent<AppProps> = ({
             labels={labels}
             selectedTimeslot={selectedTimeslot}
             onBackClick={resetOrderDetailsStores}
+            moneyFormat={moneyFormat}
           />
         </WizardModal.Page>
         <WizardModal.Page page={BookingFormPage.SUBMISSION_LOADER}>

--- a/src/fullPageBookingForm/Components/Common/QuantitySelection/QuantitySelection.tsx
+++ b/src/fullPageBookingForm/Components/Common/QuantitySelection/QuantitySelection.tsx
@@ -98,7 +98,7 @@ export const QuantitySelection: FunctionComponent<QuantitySelectionProps> = ({
                   onIncreaseClick={() => onIncreaseClick(idx)}
                   currentQty={variant.currentQty}
                   qtyMaximum={
-                    maxLimitQty !== undefined
+                    maxLimitQty !== null && maxLimitQty !== undefined
                       ? maxLimitQty > unitsLeft
                         ? unitsLeft + variant.currentQty
                         : maxLimitQty + variant.currentQty

--- a/src/fullPageBookingForm/Components/TimeslotCard/TimeslotCard.test.tsx
+++ b/src/fullPageBookingForm/Components/TimeslotCard/TimeslotCard.test.tsx
@@ -1,8 +1,9 @@
 /** @jsx h */
 import { h } from "preact";
 import { render, screen, fireEvent } from "@testing-library/preact";
-import { withMarkup } from "../../../testUtils";
 import { TimeslotCard } from "./TimeslotCard";
+
+const defaultMoneyFormat = "${{amount}}";
 
 test("Renders content correctly", async () => {
   render(
@@ -13,14 +14,14 @@ test("Renders content correctly", async () => {
       minPrice={150}
       timezone="America/Los_Angeles"
       onSelect={jest.fn()}
+      moneyFormat={defaultMoneyFormat}
     />,
   );
 
-  expect(screen.getByText(/3:00pm - 7:00pm/i)).toBeInTheDocument();
+  expect(screen.getAllByText(/6:00am - 10:00am/i)).toHaveLength(1);
   expect(screen.getByText(/4 spots left/i)).toBeInTheDocument();
-  expect(
-    withMarkup(screen.getByText)("From $150 / person"),
-  ).toBeInTheDocument();
+  expect(screen.getByText("From $150.00")).toBeInTheDocument();
+  expect(screen.getByText("/ person")).toBeInTheDocument();
   expect(screen.getByText(/select/i)).toBeInTheDocument();
 });
 
@@ -35,6 +36,7 @@ test("Calls onSelect callback", () => {
       minPrice={150}
       timezone={"Asia/Manila"}
       onSelect={handleSelect}
+      moneyFormat={defaultMoneyFormat}
     />,
   );
 

--- a/src/fullPageBookingForm/Components/TimeslotCard/TimeslotCard.tsx
+++ b/src/fullPageBookingForm/Components/TimeslotCard/TimeslotCard.tsx
@@ -5,6 +5,7 @@ import { Button } from "../Common/Button";
 import { Card } from "../Common/Card";
 import { TextStyle } from "../Common/TextStyle";
 import "./TimeslotCard.scss";
+import { formatCurrency } from "../../../Utils/helpers";
 
 export type TimeslotCardProps = {
   startsAt: Date;
@@ -13,6 +14,7 @@ export type TimeslotCardProps = {
   remainingSpots: number;
   minPrice: number;
   onSelect: () => void;
+  moneyFormat: string;
 };
 
 export const TimeslotCard: FunctionComponent<TimeslotCardProps> = ({
@@ -21,6 +23,7 @@ export const TimeslotCard: FunctionComponent<TimeslotCardProps> = ({
   timezone,
   remainingSpots,
   minPrice,
+  moneyFormat,
   onSelect,
 }) => {
   const formattedStartsAt = moment(startsAt).tz(timezone).format("h:mma");
@@ -46,7 +49,11 @@ export const TimeslotCard: FunctionComponent<TimeslotCardProps> = ({
           <div className="timeslot-card__details__pricing">
             <TextStyle
               variant="display1"
-              text={minPrice ? `From $${minPrice}` : "Free"}
+              text={
+                minPrice
+                  ? `From ${formatCurrency(moneyFormat, minPrice)}`
+                  : "Free"
+              }
             />
             <TextStyle variant="body1" text=" / person" />
           </div>

--- a/src/fullPageBookingForm/Components/Views/OrderDetails/OrderDetails.tsx
+++ b/src/fullPageBookingForm/Components/Views/OrderDetails/OrderDetails.tsx
@@ -35,8 +35,11 @@ import {
 } from "../../Common/WizardModal";
 import moment from "moment-timezone";
 import { getCart } from "../../../../Utils/api";
+import { formatCurrency } from "../../../../Utils/helpers";
 
 export type OrderDetailsProps = {
+  /**Format for money in shop. */
+  moneyFormat: string;
   /** This is the timeslot that the user has selected for the order */
   selectedTimeslot: Availability;
   /** This is the event for which the order is being created */
@@ -53,6 +56,7 @@ export type OrderDetailsProps = {
 
 export const OrderDetails: FunctionComponent<OrderDetailsProps> = ({
   event,
+  moneyFormat,
   selectedTimeslot,
   labels,
   isStorybookTest,
@@ -553,7 +557,10 @@ export const OrderDetails: FunctionComponent<OrderDetailsProps> = ({
             </div>
           </div>
           <div>
-            <TextStyle variant="body2" text={`From $${minCost} `} />
+            <TextStyle
+              variant="body2"
+              text={`From ${formatCurrency(moneyFormat, minCost)} `}
+            />
             <TextStyle variant="body1" text={"/ person"} />
           </div>
           <div className="OrderDetails__Header-Rule" />
@@ -574,14 +581,20 @@ export const OrderDetails: FunctionComponent<OrderDetailsProps> = ({
                     <div className="OrderDetails__Overview__Values__Total">
                       <TextStyle
                         variant="body1"
-                        text={`$${variant.currentQty * variant.price}`}
+                        text={`${formatCurrency(
+                          moneyFormat,
+                          variant.currentQty * variant.price,
+                        )}`}
                       />
                     </div>
                   </div>
                 ))}
               <div className="OrderDetails__Overview__Total">
                 <TextStyle variant="body2" text="Total" />
-                <TextStyle variant="body2" text={`$${variantTotal}`} />
+                <TextStyle
+                  variant="body2"
+                  text={`${formatCurrency(moneyFormat, variantTotal)}`}
+                />
               </div>
             </div>
           )}

--- a/src/fullPageBookingForm/Components/Views/TimeslotSelection/TimeslotSelection.tsx
+++ b/src/fullPageBookingForm/Components/Views/TimeslotSelection/TimeslotSelection.tsx
@@ -28,6 +28,7 @@ export const TimeslotSelection: FunctionComponent = () => {
     (state) => state.setSelectedTimeslot,
   );
   const { setPage, close } = useWizardModalAction();
+  const [hasMoreAvailableDates, setHasMoreAvailableDates] = useState(true);
   const [calendarDrawerOpen, setCalendarOpen] = useState(false);
   const [currentDate, setCurrentDate] = useState(new Date());
   const [currentMonth, setCurrentMonth] = useState(currentDate.getMonth());
@@ -40,6 +41,7 @@ export const TimeslotSelection: FunctionComponent = () => {
     availabilities,
     timeslotsByDay,
     fetchMoreFromList,
+    hasMoreAvailabilites,
   } = useAvailabilities({
     date: currentDate,
     month: currentMonth,
@@ -82,9 +84,15 @@ export const TimeslotSelection: FunctionComponent = () => {
 
   const handleYearChange = (year: number) => setCurrentYear(year);
 
-  const handleLoadMore = () => {
+  /**Loads more events on callback from infinite scroller. */
+  const handleLoadMore = async () => {
     if (!isFetchingMoreFromList) {
-      fetchMoreFromList();
+      const hasMore = await hasMoreAvailabilites();
+      setHasMoreAvailableDates(hasMore);
+
+      if (hasMore) {
+        fetchMoreFromList();
+      }
     }
   };
 
@@ -148,7 +156,7 @@ export const TimeslotSelection: FunctionComponent = () => {
 
     return (
       <InfiniteScroll
-        hasMore
+        hasMore={hasMoreAvailableDates}
         useWindow={false}
         getScrollParent={() => document.querySelector(".wizard-modal__root")}
         loadMore={handleLoadMore}

--- a/src/fullPageBookingForm/Components/Views/TimeslotSelection/TimeslotSelection.tsx
+++ b/src/fullPageBookingForm/Components/Views/TimeslotSelection/TimeslotSelection.tsx
@@ -23,7 +23,14 @@ import "./TimeslotSelection.scss";
 import { Button } from "../../Common/Button";
 import { Donger } from "../../Common/Icon/Donger";
 
-export const TimeslotSelection: FunctionComponent = () => {
+export type TimeslotSelectionProps = {
+  /**Format for money in shop. */
+  moneyFormat: string;
+};
+
+export const TimeslotSelection: FunctionComponent<TimeslotSelectionProps> = ({
+  moneyFormat,
+}) => {
   const setSelectedTimeslot = useTimeslotStore(
     (state) => state.setSelectedTimeslot,
   );
@@ -174,6 +181,7 @@ export const TimeslotSelection: FunctionComponent = () => {
 
               return {
                 minPrice,
+                moneyFormat: moneyFormat,
                 startsAt: new Date(timeslot.startsAt),
                 endsAt: new Date(timeslot.endsAt),
                 remainingSpots: timeslot.unitsLeft,

--- a/src/fullPageBookingForm/__mocks__/CustomForm.ts
+++ b/src/fullPageBookingForm/__mocks__/CustomForm.ts
@@ -47,6 +47,7 @@ export const defaultPerAttendeeFormProps: PerAttendeeTypeProps = {
       name: "Per Attendee Form",
     },
   ],
+  minLimit: 0,
   removeVariantModal: {
     variantToRemove: "",
     isOpen: false,


### PR DESCRIPTION
Additionally, fixes the disabling of the "plus" button if a max limit isn't set in the experience, as well as fixes the "empty card" on load in the time slot selection view if there are no new events to fetch in the experience.